### PR TITLE
Modal de asociar ingredientes visible

### DIFF
--- a/frontend/components/Products/TabProducts/AssociateIngredients.tsx
+++ b/frontend/components/Products/TabProducts/AssociateIngredients.tsx
@@ -32,10 +32,9 @@ interface IngredientDialogProps {
   open: boolean;
   onClose: () => void;
   onSave: (ingredientsForm: IingredientForm[]) => void;
-  PaperProps?: PaperProps;
 }
 
-const IngredientDialog: React.FC<IngredientDialogProps> = ({ open, onClose, onSave, PaperProps }) => {
+const IngredientDialog: React.FC<IngredientDialogProps> = ({ open, onClose, onSave, }) => {
   const [unit, setUnit] = useState<IUnitOfMeasure[]>([]);
   const [ingredients, setIngredients] = useState<Iingredient[]>([]);
   const [selectedIngredients, setSelectedIngredients] = useState<IingredientForm[]>([]);
@@ -102,7 +101,7 @@ const IngredientDialog: React.FC<IngredientDialogProps> = ({ open, onClose, onSa
   };
 
   return (
-    <Dialog open={open} onClose={onClose} PaperProps={PaperProps} >
+    <Dialog open={open} onClose={onClose}  >
       <DialogTitle>Asociar Ingredientes</DialogTitle>
       <DialogContent>
         {/* Sección para agregar un nuevo ingrediente */}
@@ -136,10 +135,10 @@ const IngredientDialog: React.FC<IngredientDialogProps> = ({ open, onClose, onSa
             onChange={(e) =>
               setNewIngredient({ ...newIngredient, quantityOfIngredient: +e.target.value })
             }
-            sx={{ minWidth: 120, width: "20%" }}
+            sx={{ minWidth: 120, width: "15%" }}
           />
-          <FormControl variant="outlined" sx={{ minWidth: 120, width: "40%" }}>
-            <InputLabel>Unidad de medida</InputLabel>
+          <FormControl variant="outlined" sx={{ minWidth: 120, width: "45%" }}>
+            <InputLabel sx={{ fontSize: "15px" }}>Unidad de Medida</InputLabel>
             <Select
               label="Unidad de medida"
               value={newIngredient.unitOfMeasureId}
@@ -154,9 +153,7 @@ const IngredientDialog: React.FC<IngredientDialogProps> = ({ open, onClose, onSa
               ))}
             </Select>
           </FormControl>
-
         </FormControl>
-
         <Button
           onClick={handleAddIngredient}
           variant="contained"

--- a/frontend/components/Products/TabProducts/ProductDialog.tsx
+++ b/frontend/components/Products/TabProducts/ProductDialog.tsx
@@ -233,24 +233,19 @@ export const ProductDialog: React.FC<ProductDialogProps> = ({
         <Button onClick={onClose} color="error">
           Cancelar
         </Button>
-        <Button onClick={handleSaveProduct} color="primary" disabled={!isFormValid}>
-          Guardar
-        </Button>
         <Button onClick={handleOpenIngredientDialog} color="secondary">
           Asociar Ingredientes
         </Button>
+        <Button onClick={handleSaveProduct} color="primary" disabled={!isFormValid}>
+          Guardar
+        </Button>
+
       </DialogActions>
       <IngredientDialog
         open={isIngredientDialogOpen}
         onClose={() => setIngredientDialogOpen(false)}
         onSave={handleSaveIngredients}
-        PaperProps={{
-          sx: {
-            position: "absolute",
-            left: "calc(100% + 16px)", // Ajusta según la posición deseada
-            top: 0,
-          },
-        }}
+
       />
     </Dialog>
   );


### PR DESCRIPTION
Falta obtener datos sobre los ingredientes asociados al productos, una vez ajustado el back se logrará ver en el editor de productos e ingredientes asociados. 